### PR TITLE
Slight ReadMe adjustment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Mendix widget to block the user from closing the browser, closing the tab, or cl
 
 ## Features
 - Based on a boolean expression, dynamically enable the browsers onBeforeUnload event. 
+- Based on a boolean expression, on any Mendix navigation execute a flow.
 - Based on a boolean expression, block any Mendix navigation with a confirmation message.
 - Tested and works in Chrome, Safari, Microsoft Edge, and Firefox
 

--- a/src/UnsavedChangesMessage.tsx
+++ b/src/UnsavedChangesMessage.tsx
@@ -14,6 +14,7 @@ const callMxAction = (action: ActionValue | undefined): void => {
 };
 
 function onClickHandler(
+    showChoicePopup: boolean,
     x: number,
     y: number,
     bodyText: string,
@@ -22,7 +23,14 @@ function onClickHandler(
     onProceed: ActionValue | undefined,
     debugMode: boolean
 ): void {
-    MxConfirmation(bodyText, proceedCaption, cancelCaption, () => {
+    if(showChoicePopup){
+        MxConfirmation(bodyText, proceedCaption, cancelCaption, ProceedAndClickClickedHtmlItem());
+    }
+    else{
+        ProceedAndClickClickedHtmlItem();
+    }
+
+    function ProceedAndClickClickedHtmlItem() {
         callMxAction(onProceed);
         const elementsAtPoint = document.elementsFromPoint(x, y);
         if (elementsAtPoint.length > 1) {
@@ -35,12 +43,13 @@ function onClickHandler(
             // eslint-disable-next-line no-unused-expressions
             debugMode && console.warn("No elements found under the points: {x: " + x + ", y: " + y + "}");
         }
-    });
+    }
 }
 
 export function UnsavedChangesMessage({
     block,
     name,
+    showChoicePopup,
     debugMode,
     style,
     onChangeBlock,
@@ -127,6 +136,7 @@ export function UnsavedChangesMessage({
                             <Blocker
                                 key={index}
                                 watchingElement={htmlElement}
+                                showChoicePopup={showChoicePopup}
                                 debugMode={debugMode}
                                 navbarWidth={
                                     htmlElement.classList.contains(navigationMenuClass)
@@ -135,6 +145,7 @@ export function UnsavedChangesMessage({
                                 }
                                 onClick={(x, y) =>
                                     onClickHandler(
+                                        showChoicePopup,
                                         x,
                                         y,
                                         bodyText.value as string,

--- a/src/UnsavedChangesMessage.xml
+++ b/src/UnsavedChangesMessage.xml
@@ -25,6 +25,11 @@
                     <description>Boolean expression that determines whether or not to show the message.</description>
                     <returnType type="Boolean" />
                 </property>
+                <property key="showChoicePopup" type="boolean" defaultValue="true">
+                    <caption>Show choice popup?</caption>
+                    <description>If true, popup will get shown: Proceed or Cancel?
+If false, no popup will be shown. Action OnProcess will immediately get executed.</description>
+                </property>
                 <property key="debugMode" type="boolean" defaultValue="true">
                     <caption>Debug Mode?</caption>
                     <description>DISABLE PRIOR TO PRODUCTION DEPLOYMENT</description>

--- a/src/components/Blocker.tsx
+++ b/src/components/Blocker.tsx
@@ -4,6 +4,7 @@ import { usePositionObserver } from "../utils/usePositionObserver";
 
 interface BlockerProps {
     watchingElement: Element;
+    showChoicePopup: boolean;
     debugMode: boolean;
     navbarWidth: number | undefined;
     onClick: (x: number, y: number) => void;

--- a/typings/UnsavedChangesMessageProps.d.ts
+++ b/typings/UnsavedChangesMessageProps.d.ts
@@ -15,6 +15,7 @@ export interface UnsavedChangesMessageContainerProps {
     tabIndex?: number;
     observeMode: ObserveModeEnum;
     block: DynamicValue<boolean>;
+    showChoicePopup: boolean;
     debugMode: boolean;
     watchingClass: string;
     sidebarClass: string;
@@ -37,6 +38,7 @@ export interface UnsavedChangesMessagePreviewProps {
     readOnly: boolean;
     observeMode: ObserveModeEnum;
     block: string;
+    showChoicePopup: boolean;
     debugMode: boolean;
     watchingClass: string;
     sidebarClass: string;


### PR DESCRIPTION
Added the option to perform an action upon leaving the page, without first getting the confirmation-popup.
Our use case was the necessity to unblock the object on the page, since we block the object upon opening the page, and that should only be for the duration of having the page open.
Truly hope you will accept this pull-request and we are very willing to explain further.